### PR TITLE
Fix 3 bugs in BERT classifier and add project scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Hugging Face access token (required for dataset and model access)
+HUGGINGFACE_TOKEN=hf_...
+
+# OpenAI API key (required for GPT-4o inference scripts)
+OPEN_AI_API=sk-...
+
+# MongoDB connection (required for data collection system)
+# MONGO_URI=mongodb://localhost:27017
+
+# Google OAuth (required for admin page; see README for credential setup)
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.egg
+*.egg-info/
+dist/
+build/
+.eggs/
+*.whl
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Secrets & credentials
+.env
+*.env
+sheet_credential.json
+token.json
+*.key
+*.pem
+
+# ML artifacts
+results/
+outputs/
+*.pt
+*.bin
+*.safetensors
+*.ckpt
+checkpoint-*/
+runs/
+wandb/
+
+# Data
+*.csv
+*.jsonl
+*.parquet
+
+# Jupyter
+.ipynb_checkpoints/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/scholawrite_finetune/bert_finetune/small_model_classifier.py
+++ b/scholawrite_finetune/bert_finetune/small_model_classifier.py
@@ -78,12 +78,12 @@ def get_model_tokenizer(model_name):
   return model, tokenizer
 
 def add_intention_inference_instruction_input(dataset_df, include_prev_label=False):
-  dataset_df["instruction input"] = "<INPUT>" + "<BT>" + dataset_df["before text"] + "</BF> "
+  dataset_df["instruction input"] = "<INPUT>" + "<BT>" + dataset_df["before text"] + "</BT> "
 
   if (include_prev_label):
     dataset_df["prev_label"] = dataset_df["label"].shift(1).fillna("none")
     dataset_df["instruction input"] += "<PWA>" + dataset_df["prev_label"] + "</PWA> "
-    dataset_df.remove_columns(columns=["prev_label"])
+    dataset_df.drop(columns=["prev_label"], inplace=True)
 
   dataset_df["instruction input"] += "</INPUT>"
 
@@ -129,7 +129,7 @@ test_ds.set_format("torch")
 def dataset_statistics(dataset, dataset_name):
   labels, counts = dataset["label"].unique(return_counts=True)
 
-  labels = d.le.inverse_transform(labels.tolist())
+  labels = le.inverse_transform(labels.tolist())
   counts = counts.tolist()
 
   tup = zip(labels, counts)


### PR DESCRIPTION
## Summary

### Bug fixes in `scholawrite_finetune/bert_finetune/small_model_classifier.py`

**Bug 1 — Token tag mismatch (silent data corruption)**
```python
# Before (wrong closing tag — every training sample is malformed)
dataset_df["instruction input"] = "<INPUT>" + "<BT>" + dataset_df["before text"] + "</BF> "
# After
dataset_df["instruction input"] = "<INPUT>" + "<BT>" + dataset_df["before text"] + "</BT> "
```
`</BF>` was never registered as a special token, so the tokenizer sees it as plain text. All training data built with this path is silently corrupt.

**Bug 2 — `AttributeError` crash at runtime**
```python
# Before — pandas DataFrame has no remove_columns() method
dataset_df.remove_columns(columns=["prev_label"])
# After
dataset_df.drop(columns=["prev_label"], inplace=True)
```

**Bug 3 — `NameError`: undefined variable `d`**
```python
# Before
labels = d.le.inverse_transform(labels.tolist())
# After
labels = le.inverse_transform(labels.tolist())
```
`d` is never defined; this crashes `dataset_statistics()`.

### Scaffolding
- Added `.gitignore` (excludes checkpoints, data files, credentials)
- Added `.env.example` documenting required secrets (`HUGGINGFACE_TOKEN`, `OPEN_AI_API`)

## Test plan
- [ ] Run `python small_model_classifier.py` end-to-end — verify no crash
- [ ] Inspect `train_ds["instruction input"][0]` — confirm it ends with `</BT> </INPUT>` not `</BF> </INPUT>`
- [ ] Call `dataset_statistics(train_ds, "train")` — confirm no NameError

https://claude.ai/code/session_019aKvkKExRdWN6fBqinkQC3