### PR TITLE
fix: pass fname explicitly to calculate_metrics instead of relying on global scope

### DIFF
--- a/analysis/classification_stats.py
+++ b/analysis/classification_stats.py
@@ -25,7 +25,7 @@ fnames = [
 "BERT_BASE_run_final.csv"
 ]
 
-def calculate_metrics(eval_df):
+def calculate_metrics(eval_df, fname):
 
   y_true = eval_df["label"]
 
@@ -61,4 +61,4 @@ def calculate_metrics(eval_df):
 
 for fname in fnames:
   df = pd.read_csv(fname)
-  calculate_metrics(df)
+  calculate_metrics(df, fname)


### PR DESCRIPTION
The `calculate_metrics()` function references the outer-scope `fname` variable implicitly when generating confusion matrix filenames:

```python
plt.savefig(f"conf_mats/confusion_matrix_{os.path.basename(fname)}.pdf", format="pdf")
```

This function doesn't take `fname` as a parameter, so it relies on the global `fname` being set correctly at call time. While this works when called inside the `for fname in fnames:` loop today, it:
- Makes `calculate_metrics` non-reusable (breaks if called standalone)
- Creates confusing implicit state — the function signature says it only needs `eval_df`
- Would silently use the initial global `fname` value if the loop is refactored

Fix: add `fname` as an explicit parameter.