### PR TITLE
fix: correct token tag mismatches in training scripts

### DIFF
--- a/scholawrite_finetune/bert_finetune/small_model_inference.py
+++ b/scholawrite_finetune/bert_finetune/small_model_inference.py
@@ -61,12 +61,12 @@ def get_model_tokenizer(model_name):
   return model, tokenizer
 
 def add_intention_inference_instruction_input(dataset_df, include_prev_label=False):
-  dataset_df["instruction input"] = "<INPUT>" + "<BT>" + dataset_df["before text"] + "</BF> "
+  dataset_df["instruction input"] = "<INPUT>" + "<BT>" + dataset_df["before text"] + "</BT> "
 
   if (include_prev_label):
     dataset_df["prev_label"] = dataset_df["label"].shift(1).fillna("none")
     dataset_df["instruction input"] += "<PWA>" + dataset_df["prev_label"] + "</PWA> "
-    dataset_df.remove_columns(columns=["prev_label"])
+    dataset_df.drop(columns=["prev_label"], inplace=True)
 
   dataset_df["instruction input"] += "</INPUT>"
 


### PR DESCRIPTION
## Summary

Fixes #7 — Audit all training scripts for token tag mismatches (`</BF>` pattern).

### Changes in `scholawrite_finetune/bert_finetune/small_model_inference.py`

- **Token tag mismatch (line 64)**: `</BF>` was used as the closing tag for a `<BT>` opening tag inside `add_intention_inference_instruction_input()`. This is a copy-paste error — the correct closing tag is `</BT>`, which is already used correctly in the parallel `small_model_classifier.py`.

- **Wrong DataFrame API (line 69)**: `dataset_df.remove_columns(columns=["prev_label"])` used a HuggingFace `Dataset` method on a pandas `DataFrame`, which would raise an `AttributeError` at runtime. Replaced with the correct `dataset_df.drop(columns=["prev_label"], inplace=True)`, consistent with `small_model_classifier.py` line 86.

## Test plan
- [ ] Confirm `</BF>` no longer appears in any `.py` training script
- [ ] Confirm `add_intention_inference_instruction_input()` in `small_model_inference.py` now matches the implementation in `small_model_classifier.py`
- [ ] Run inference script to verify no `AttributeError` on the `prev_label` cleanup path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xxg3zyqmUDLKxQ6nNEVn3